### PR TITLE
Updated vcf-to-proteindb to parse using pandas

### DIFF
--- a/pypgatk/commands/vcf_to_proteindb.py
+++ b/pypgatk/commands/vcf_to_proteindb.py
@@ -29,6 +29,16 @@ this_dir, this_filename = os.path.split(__file__)
 @click.option('--af_threshold', default=0.01, help='Minium AF threshold for considering common variants')
 @click.option('--transcript_str', default='FEATURE', type=str,
               help='String that is used for transcript ID in the VCF header INFO field')
+
+@click.option('--biotype_str', default='BIOTYPE', type=str,
+              help='String that is used for biotype in the VCF header INFO field')
+@click.option('--exclude_biotypes',
+              default='',
+              help="Excluded Biotypes", show_default=True)
+@click.option('--include_biotypes', 
+              default='protein_coding,polymorphic_pseudogene,non_stop_decay,nonsense_mediated_decay,IG_C_gene,IG_D_gene,IG_J_gene,IG_V_gene,TR_C_gene,TR_D_gene,TR_J_gene,TR_V_gene,TEC,mRNA', 
+              help="included_biotypes, default all")
+
 @click.option('--consequence_str', default='CONSEQUENCE', type=str,
               help='String that is used for consequence in the VCF header INFO field')
 @click.option('--exclude_consequences',
@@ -41,13 +51,14 @@ this_dir, this_filename = os.path.split(__file__)
 @click.option('--ignore_filters',
               help="enabling this option causes or variants to be parsed. By default only variants that have not failed any filters will be processed (FILTER column is PASS, None, .) or if the filters are subset of the accepted filters. (default is False)",
               is_flag=True)
-@click.option('--accepted_filters', default='', help="Accepted filters for variant parsing")
+@click.option('--accepted_filters', default='PASS', help="Accepted filters for variant parsing")
 @click.pass_context
 def vcf_to_proteindb(ctx, config_file, input_fasta, vcf, gene_annotations_gtf, translation_table,
                      mito_translation_table,
                      var_prefix, report_ref_seq, output_proteindb, annotation_field_name,
-                     af_field, af_threshold, transcript_str, consequence_str,
-                     exclude_consequences, skip_including_all_cds, include_consequences,
+                     af_field, af_threshold, transcript_str, biotype_str, exclude_biotypes, 
+                     include_biotypes, consequence_str, exclude_consequences, 
+                     skip_including_all_cds, include_consequences,
                      ignore_filters, accepted_filters):
   if input_fasta is None or vcf is None or gene_annotations_gtf is None:
     print_help()
@@ -60,6 +71,9 @@ def vcf_to_proteindb(ctx, config_file, input_fasta, vcf, gene_annotations_gtf, t
                         EnsemblDataService.ANNOTATION_FIELD_NAME: annotation_field_name,
                         EnsemblDataService.AF_FIELD: af_field, EnsemblDataService.AF_THRESHOLD: af_threshold,
                         EnsemblDataService.TRANSCRIPT_STR: transcript_str,
+                        EnsemblDataService.BIOTYPE_STR: biotype_str,
+                        EnsemblDataService.EXCLUDE_BIOTYPES: exclude_biotypes,
+                        EnsemblDataService.INCLUDE_BIOTYPES: include_biotypes,
                         EnsemblDataService.CONSEQUENCE_STR: consequence_str,
                         EnsemblDataService.EXCLUDE_CONSEQUENCES: exclude_consequences,
                         EnsemblDataService.SKIP_INCLUDING_ALL_CDS: skip_including_all_cds,

--- a/pypgatk/config/ensembl_config.yaml
+++ b/pypgatk/config/ensembl_config.yaml
@@ -11,9 +11,9 @@ ensembl_translation:
     exclude_biotypes: ''
     exclude_consequences: 'downstream_gene_variant, upstream_gene_variant, intergenic_variant, intron_variant, synonymous_variant, regulatory_region_variant'
     skip_including_all_cds: False
-    include_biotypes: 'protein_coding,polymorphic_pseudogene,non_stop_decay,nonsense_mediated_decay,IG_C_gene,IG_D_gene,IG_J_gene,IG_V_gene,TR_C_gene,TR_D_gene,TR_J_gene,TR_V_gene,TEC'
+    include_biotypes: 'protein_coding,polymorphic_pseudogene,non_stop_decay,nonsense_mediated_decay,IG_C_gene,IG_D_gene,IG_J_gene,IG_V_gene,TR_C_gene,TR_D_gene,TR_J_gene,TR_V_gene,TEC,mRNA'
     include_consequences: 'all'
-    biotype_str: 'feature_biotype'
+    biotype_str: biotype
     transcript_str: 'FEATURE'
     consequence_str: 'CONSEQUENCE'
     num_orfs: 3
@@ -21,7 +21,7 @@ ensembl_translation:
     expression_str: ""
     expression_thresh: 5.0
     ignore_filters: False
-    accepted_filters: ''
+    accepted_filters: 'PASS'
   logger:
     formatters:
       DEBUG: "%(asctime)s [%(levelname)7s][%(name)48s][%(module)32s, %(lineno)4s] %(message)s"

--- a/pypgatk/tests/pypgatk_tests.py
+++ b/pypgatk/tests/pypgatk_tests.py
@@ -17,7 +17,9 @@ def vcf_to_proteindb():
                           '--var_prefix', 'ensvar',
                           '--af_field', 'MAF',
                           '--output_proteindb', 'testdata/proteindb_from_ENSEMBL_VCF.fa',
-                          '--annotation_field_name', 'CSQ'])
+                          '--annotation_field_name', 'CSQ',
+                          '--biotype_str', 'feature_type',
+                          '--include_biotypes', 'mRNA,ncRNA'])
   assert result.exit_code == 0
 
 
@@ -34,7 +36,7 @@ def vcf_to_proteindb_notannotated():
                           '--gene_annotations_gtf', 'testdata/test.gtf',
                           '--var_prefix', 'varsample',
                           '--output_proteindb', 'testdata/proteindb_from_custom_VCF.fa',
-                          '--annotation_field_name', "''"])
+                          '--annotation_field_name', ""])
   assert result.exit_code == 0
 
 
@@ -51,8 +53,9 @@ def vcf_gnomad_to_proteindb():
                           '--gene_annotations_gtf', 'testdata/test_gencode.gtf',
                           '--output_proteindb', 'testdata/proteindb_from_gnomad_VCF.fa',
                           '--af_field', 'controls_AF',
+                          '--af_threshold', '0.001',
                           '--var_prefix', 'gnomvar',
-                          '--annotation_field_name', 'vep'])
+                          '--annotation_field_name', 'vep',])
   assert result.exit_code == 0
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ biopython==1.73
 Click==7.0
 gffutils==0.10.1
 numpy==1.16.3
-PyVCF==0.6.8
 PyYAML==5.1.2
 requests==2.21.0
 simplejson==3.16.0
 ratelimit==2.2.1
 pyteomics==4.4.2
 pybedtools==0.8.2
+pandas==1.2.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ simplejson==3.16.0
 ratelimit==2.2.1
 pyteomics==4.4.2
 pybedtools==0.8.2
-pandas==1.2.3
+pandas==1.2
 


### PR DESCRIPTION

- Pandas dataframes are used to work with the VCF records therefore, the older pyvcf package is no longer needed
- Also, variants can be filtered based on the biotype of their overlapping transcripts (only for pre-annotated VCF files)
since only protein-coding transcripts are used to translate unannotated VCFs.
-Updated some fields including variant filtering and default values.