### PR TITLE
chore: address CodeRabbit follow-up findings

### DIFF
--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -259,7 +259,8 @@ else
             ensembl_human/homo_sapiens_incl_consequences-chr*.vcf \
             ensembl_human/homo_sapiens_incl_consequences-chr*.vcf.gz; do
         [[ -f "${VCF_CHR}" ]] || continue
-        CHROM=$(basename "${VCF_CHR}" | grep -oP '(?<=consequences-)chr\w+(?=\.vcf)')
+        # Strip leading "...consequences-" and trailing ".vcf[.gz]"; portable (no grep -P).
+        CHROM=$(basename "${VCF_CHR}" | sed -E 's/.*consequences-//; s/\.vcf(\.gz)?$//')
         pgatk vcf-to-proteindb \
             --vcf "${VCF_CHR}" \
             --input_fasta ensembl_human/transcripts.fa \

--- a/pgatk/commands/ensembl_downloader.py
+++ b/pgatk/commands/ensembl_downloader.py
@@ -127,7 +127,16 @@ def ensembl_downloader(ctx, config_file, output_directory, taxonomy, folder_pref
 
             for gtf_path in gtf_files:
                 prefix = ".".join(os.path.basename(gtf_path).split(".")[:2])
-                genome_fna = genome_map.get(prefix) or next(iter(genome_map.values()))
+                genome_fna = genome_map.get(prefix)
+                if genome_fna is None:
+                    fallback = next(iter(genome_map.values()))
+                    click.echo(
+                        f"Warning: no genome with prefix '{prefix}' found "
+                        f"(available: {sorted(genome_map)}); "
+                        f"falling back to {os.path.basename(fallback)}.",
+                        err=True,
+                    )
+                    genome_fna = fallback
                 output_fasta = os.path.join(
                     out_dir,
                     "transcripts.fa" if len(gtf_files) == 1 else f"{prefix}_transcripts.fa",

--- a/pgatk/commands/gencode_downloader.py
+++ b/pgatk/commands/gencode_downloader.py
@@ -1,4 +1,5 @@
 import os
+import subprocess  # nosec B404 - imported only to catch CalledProcessError from gffread
 
 import click
 
@@ -65,6 +66,6 @@ def gencode_downloader(ctx, output_dir, release, force, generate_transcripts):
             click.echo("Running gffread to generate transcripts.fa with CDS= headers ...")
             GencodeDownloader.generate_transcripts(genome_fna, gtf_file, output_fasta)
             click.echo(f"Transcripts written to {output_fasta}")
-        except FileNotFoundError as exc:
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
             click.echo(f"Error: {exc}", err=True)
             raise SystemExit(1)

--- a/pgatk/testdata/clinvar/mini_clinvar.vcf
+++ b/pgatk/testdata/clinvar/mini_clinvar.vcf
@@ -3,6 +3,11 @@
 ##INFO=<ID=CLNSIG,Number=.,Type=String,Description="Clinical significance">
 ##INFO=<ID=MC,Number=.,Type=String,Description="Molecular consequence">
 ##INFO=<ID=GENEINFO,Number=1,Type=String,Description="Gene(s) for this variant">
+## Test fixture: rs00002 and rs00004 are intentionally placed at the same 1:69550 G>A
+## position with different rsIDs and conflicting MC annotations. They exercise the
+## independent CLNSIG/MC filtering paths in test_clinvar_service.py /
+## test_clinvar_integration.py — rs00002 (Benign) must be dropped by significance
+## filtering and rs00004 (synonymous) must be dropped by consequence filtering.
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
 1	69500	rs00001	T	C	.	.	GENEINFO=OR4F5:79501;CLNSIG=Pathogenic;MC=SO:0001583|missense_variant
 1	69550	rs00002	G	A	.	.	GENEINFO=OR4F5:79501;CLNSIG=Benign;MC=SO:0001583|missense_variant


### PR DESCRIPTION
## Summary

Acts on the actionable findings from a CodeRabbit `--agent` review of the branch. Each item was verified against current code before fixing.

- **`docs/use-cases.md:262` (major)** — replace non-portable `grep -oP` (PCRE lookbehind, GNU-only) with `sed -E` so the per-chromosome ENSEMBL example works on default macOS / BSD grep. Also handles the `.vcf.gz` variant in one pass.
- **`pgatk/commands/gencode_downloader.py:69` (minor)** — also catch `subprocess.CalledProcessError` from gffread. Matches what `ensembl_downloader.py:139` and `ncbi_downloader.py` already do; previously a gffread failure during `--generate-transcripts` would bubble up as an uncaught traceback.
- **`pgatk/commands/ensembl_downloader.py:130` (minor)** — when no genome matches a GTF's prefix, the loop silently fell back to `next(iter(genome_map.values()))`. Now warns with the missing prefix and the fallback assembly name so users can spot a GRCh38-GTF / GRCh37-genome mismatch.
- **`pgatk/testdata/clinvar/mini_clinvar.vcf:8-10` (minor)** — add a header comment documenting that the two records at `1:69550 G>A` are intentional: rs00002 (Benign, missense) exercises CLNSIG filtering and rs00004 (Pathogenic, synonymous) exercises consequence filtering. Both assertions live in `test_clinvar_service.py` / `test_clinvar_integration.py`.

### Skipped

- `pgatk/commands/cbioportal_to_proteindb.py:99` — CodeRabbit suggested changing `if workers > 1` to `if workers is not None`. The click option defaults to `1` and `CancerGenomesService` also defaults to 1 when `WORKERS` is unset (`cgenomes_proteindb.py:411`), so `--workers 1` and "no flag" produce identical behaviour. The guard is not a user-visible bug.

## Test plan

- [x] `python -m pytest pgatk/tests/ -q` — 315 passed
- [x] `python -m unittest discover -s pgatk/tests -p "*_tests.py"` — 20/20 passed