### PR TITLE
chore: address CodeRabbit + Copilot findings from PR #105

### DIFF
--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -108,7 +108,7 @@ pgatk dnaseq-to-proteindb \
 
 #### Putative proteins (three-frame)
 
-Protein coding genes without CDs that are not validated but annoated:
+Protein coding genes without CDs that are not validated but annotated:
 
 ```bash
 pgatk dnaseq-to-proteindb \
@@ -511,7 +511,7 @@ therapy resistance, and prioritize neoantigen candidates. The databases combine
 somatic mutations from cancer-specific sources (COSMIC, cBioPortal) and/or
 patient-matched whole-exome sequencing.
 
-### 4a. Cancer-speific database using COSMIC somatic mutations
+### 4a. Cancer-specific database using COSMIC somatic mutations
 
 Generate one protein database per primary tissue site. This is the standard
 approach for large-scale cancer proteogenomics when patient-level WES is not
@@ -543,7 +543,7 @@ etc. Use the tissue-matched database for your cancer type of interest.
     and is joined via `COSMIC_PHENOTYPE_ID`. Pass the Classification file via
     `--clinical_sample_file` whenever tissue-type filtering or splitting is needed.
 
-### 4b. Cancer-type speific database using COSMIC somatic mutations
+### 4b. Cancer-type specific database using COSMIC somatic mutations
 
 Build a focused database for one cancer type (e.g. lung):
 
@@ -586,7 +586,7 @@ transcripts without a `CDS=` header). `Nonsense_Mutation` variants are excluded 
 pass `--exclude_variant_classifications ""` to override.
 
 Use `--workers N` to parallelise the translation phase across N CPU cores, beneficial
-for large pan-cancer studies with large numbre of mutations.
+for large pan-cancer studies with large number of mutations.
 
 #### GRCh37 study (e.g. TCGA PanCancer Atlas 2018)
 
@@ -1188,6 +1188,15 @@ pgatk dnaseq-to-proteindb \
     --output_proteindb pseudogene.fa \
     --protein_prefix pseudogene_ \
     --include_biotypes processed_pseudogene,transcribed_processed_pseudogene \
+    --num_orfs 3 \
+    --skip_including_all_cds
+
+# Putative proteins (three-frame translation of all protein-coding transcripts)
+pgatk dnaseq-to-proteindb \
+    --input_fasta ensembl_data/transcripts.fa \
+    --output_proteindb putative.fa \
+    --protein_prefix putative_ \
+    --include_biotypes protein_coding \
     --num_orfs 3 \
     --skip_including_all_cds
 ```

--- a/pgatk/cgenomes/cbioportal_downloader.py
+++ b/pgatk/cgenomes/cbioportal_downloader.py
@@ -342,13 +342,19 @@ class CbioPortalDownloadService(ParameterConfiguration):
                     line_count = 0
                     if self._multithreading:
                         processes = []
+                        # Pass url_file=None to workers — concurrent writes to the
+                        # shared handle would interleave/corrupt lines. The main
+                        # thread serializes the writes below.
                         with ThreadPoolExecutor(max_workers=10, thread_name_prefix='Thread-Download') as executor:
                             for row in csv_reader:
                                 if line_count != 0:
-                                    processes.append(executor.submit(self.download_one_study, row[0], url_file=url_file))
+                                    processes.append(executor.submit(self.download_one_study, row[0]))
                                 line_count = line_count + 1
                         for task in as_completed(processes):
-                            print(task.result())
+                            result = task.result()
+                            print(result)
+                            if result is not None:
+                                url_file.write(result + "\n")
                     else:
                         for row in csv_reader:
                             if line_count != 0:
@@ -407,6 +413,9 @@ class CbioPortalDownloadService(ParameterConfiguration):
 
         _fetch_clinical_data(self._cbioportal_base_url, download_study, study_dir, log)
 
+        # Note: url_file writes intentionally happen in download_study() (single-threaded
+        # main thread) after futures complete; the parameter is retained for the
+        # single-study code path and to keep the legacy serial call sites unchanged.
         if url_file is not None:
             url_file.write(out_path + "\n")
         return out_path

--- a/pgatk/cgenomes/cgenomes_proteindb.py
+++ b/pgatk/cgenomes/cgenomes_proteindb.py
@@ -161,10 +161,29 @@ def _cbio_translate_batch(rows: list, batch_idx: int) -> list:
                     log.warning("incorrect del format or record %s %s", idx, pos)
                     continue
                 del_dna = pos.split("del")[1]
-                if del_dna == seq[enst_pos - 1:enst_pos - 1 + len(del_dna)]:
-                    seq_mut = seq[:enst_pos - 1] + seq[enst_pos - 1 + len(del_dna):]
+                if del_dna:
+                    # Explicit deleted bases: verify they match the reference.
+                    if del_dna == seq[enst_pos - 1:enst_pos - 1 + len(del_dna)]:
+                        seq_mut = seq[:enst_pos - 1] + seq[enst_pos - 1 + len(del_dna):]
+                    else:
+                        log.warning("incorrect deletion, unmatched nucleotide %s", pos)
                 else:
-                    log.warning("incorrect deletion, unmatched nucleotide %s", pos)
+                    # Range deletion without explicit bases (e.g. ``c.104_124del``):
+                    # derive the deletion length from the positions in cdna_pos.
+                    parts = cdna_pos.split("_")
+                    if len(parts) >= 2:
+                        try:
+                            end_pos = int(re.findall(r'\d+', parts[1])[0])
+                        except IndexError:
+                            log.warning("incorrect del range format %s", pos)
+                            continue
+                        del_len = end_pos - enst_pos + 1
+                    else:
+                        del_len = 1
+                    if del_len <= 0 or enst_pos - 1 + del_len > len(seq):
+                        log.warning("deletion out of range for %s (len=%d)", pos, del_len)
+                        continue
+                    seq_mut = seq[:enst_pos - 1] + seq[enst_pos - 1 + del_len:]
             elif vartype == "INS":
                 try:
                     enst_pos = int(re.findall(r'\d+', cdna_pos.split("_")[0])[0])

--- a/pgatk/cgenomes/cosmic_downloader.py
+++ b/pgatk/cgenomes/cosmic_downloader.py
@@ -156,8 +156,11 @@ class CosmicDownloadService(ParameterConfiguration):
         self.get_logger().debug("Downloading file from signed URL (path %s)", download_url.split('?', 1)[0])
         data_response = requests.get(download_url, stream=True, timeout=30)
         if data_response.status_code != 200:
+            # Strip the query string so the short-lived AWS credentials don't end
+            # up in logs / log aggregators on failure.
+            redacted_url = download_url.split('?', 1)[0]
             msg = ("COSMIC S3 download failed: HTTP {} for {}"
-                   .format(data_response.status_code, download_url))
+                   .format(data_response.status_code, redacted_url))
             self.get_logger().error(msg)
             raise AppConfigException(msg)
 

--- a/pgatk/clinvar/data_downloader.py
+++ b/pgatk/clinvar/data_downloader.py
@@ -19,6 +19,9 @@ def _resolve_genome_fna(genome_fna: str) -> tuple[str, str | None]:
     gffread requires random-access into the genome FASTA.  Regular .gz does not
     support seeks, so if the caller passes a .gz path we reuse an already-
     decompressed sibling file or decompress to one on the fly.
+    Decompression is written to a sibling ``.tmp`` file and atomically renamed
+    so an interrupted run cannot leave behind a partial / corrupt FASTA that
+    later invocations would silently reuse.
     Returns the second element only when *we* created the file (caller must remove it).
     """
     if not genome_fna.endswith(".gz"):
@@ -27,8 +30,20 @@ def _resolve_genome_fna(genome_fna: str) -> tuple[str, str | None]:
     if os.path.exists(plain):
         return plain, None
     logger.info("Decompressing genome FASTA for gffread (random-access required): %s", genome_fna)
-    with gzip.open(genome_fna, "rb") as fi, open(plain, "wb") as fo:
-        shutil.copyfileobj(fi, fo)
+    tmp = plain + ".tmp"
+    try:
+        with gzip.open(genome_fna, "rb") as fi, open(tmp, "wb") as fo:
+            shutil.copyfileobj(fi, fo)
+        os.replace(tmp, plain)
+    except BaseException:
+        # On any failure (including KeyboardInterrupt) remove the partial temp
+        # file so the next run re-decompresses from scratch.
+        if os.path.exists(tmp):
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+        raise
     return plain, plain
 
 logger = logging.getLogger(__name__)

--- a/pgatk/commands/vcf_to_proteindb.py
+++ b/pgatk/commands/vcf_to_proteindb.py
@@ -39,7 +39,10 @@ log = logging.getLogger(__name__)
               is_flag=True)
 @click.option('--accepted_filters', help="Accepted filters for variant parsing")
 @click.option('-w', '--workers', type=int, default=None,
-              help="Number of worker processes to fan out across (default: 1, sequential). Per-chromosome split.")
+              help="Number of worker processes to fan out across. When omitted the "
+                   "value from the config is used (default 1, sequential). The VCF is split "
+                   "into fixed-size variant batches (~50k records each) that may span "
+                   "chromosome boundaries, not per chromosome.")
 @click.pass_context
 def vcf_to_proteindb(ctx, config_file, input_fasta, vcf, gene_annotations_gtf, translation_table,
                      mito_translation_table,

--- a/pgatk/db/map_peptide2genome.py
+++ b/pgatk/db/map_peptide2genome.py
@@ -87,20 +87,22 @@ def parse_gtf(infile):
     dic = {}
     with open(infile, "r", encoding='utf-8') as infile_object:
         for line in infile_object:
-            if line[0] != "#":
-                row = line.strip().split("\t")
-                if row[2] == "CDS":
-                    attri_list = row[8].split(";")
-                    transID = ""
-                    exon = EXON(start=int(row[3]), end=int(row[4]), chromosome=row[0], strand=row[6])
-                    for attri in attri_list:
-                        if "transcript_id" in attri:
-                            transID = attri.strip().replace("transcript_id ", "").replace('\"', "")
+            # Skip blank lines first — `line[0]` on an empty line raises IndexError.
+            if not line.strip() or line[0] == "#":
+                continue
+            row = line.strip().split("\t")
+            if len(row) > 2 and row[2] == "CDS":
+                attri_list = row[8].split(";")
+                transID = ""
+                exon = EXON(start=int(row[3]), end=int(row[4]), chromosome=row[0], strand=row[6])
+                for attri in attri_list:
+                    if "transcript_id" in attri:
+                        transID = attri.strip().replace("transcript_id ", "").replace('\"', "")
 
-                    if transID not in dic:
-                        dic[transID] = [exon]
-                    else:
-                        dic[transID].append(exon)
+                if transID not in dic:
+                    dic[transID] = [exon]
+                else:
+                    dic[transID].append(exon)
     return dic
 
 

--- a/pgatk/ensembl/data_downloader.py
+++ b/pgatk/ensembl/data_downloader.py
@@ -502,6 +502,9 @@ class EnsemblDataDownloadService(ParameterConfiguration):
                 "Install it with: conda install -c bioconda gffread"
             )
         # gffread requires random-access; decompress .gz to a sibling file when needed.
+        # The decompression is staged through a ``.tmp`` file and atomically
+        # renamed so an interrupted run cannot leave a partial sibling that a
+        # later invocation would silently reuse.
         _tmp = None
         genome_for_gffread = genome_fna
         if genome_fna.endswith(".gz"):
@@ -509,8 +512,18 @@ class EnsemblDataDownloadService(ParameterConfiguration):
             if os.path.exists(plain):
                 genome_for_gffread = plain
             else:
-                with gzip.open(genome_fna, "rb") as fi, open(plain, "wb") as fo:
-                    shutil.copyfileobj(fi, fo)
+                tmp_path = plain + ".tmp"
+                try:
+                    with gzip.open(genome_fna, "rb") as fi, open(tmp_path, "wb") as fo:
+                        shutil.copyfileobj(fi, fo)
+                    os.replace(tmp_path, plain)
+                except BaseException:
+                    if os.path.exists(tmp_path):
+                        try:
+                            os.remove(tmp_path)
+                        except OSError:
+                            pass
+                    raise
                 genome_for_gffread = plain
                 _tmp = plain
         try:

--- a/pgatk/ensembl/ensembl.py
+++ b/pgatk/ensembl/ensembl.py
@@ -135,11 +135,13 @@ def _split_vcf_into_batches(vcf_file: str, output_dir: str,
     return batch_paths
 
 
-def _vcf_to_proteindb_worker(vcf_file: str, output_path: str) -> None:
+def _vcf_to_proteindb_worker(vcf_file: str, output_path: str) -> dict:
     """Module-level worker for multiprocessing.Pool.starmap.
 
     Uses the GTF DB, FASTA index, and EnsemblDataService instance opened once
     per worker process by _worker_init rather than re-constructing them per task.
+    Returns the per-chunk stats dict that ``vcf_to_proteindb`` aggregates across
+    all workers.
     """
     svc = _worker_state['svc']
     _, stats = svc._vcf_to_proteindb_chunk(

--- a/pgatk/gnomad/data_downloader.py
+++ b/pgatk/gnomad/data_downloader.py
@@ -25,6 +25,9 @@ def _resolve_genome_fna(genome_fna: str) -> tuple[str, str | None]:
     gffread requires random-access into the genome FASTA.  Regular .gz (deflate)
     does not support seeks, so if the caller passes a .gz path we either reuse
     an already-decompressed sibling file or decompress to one on the fly.
+    Decompression is staged through a sibling ``.tmp`` file and atomically
+    renamed so an interrupted run cannot leave behind a partial / corrupt
+    FASTA that later invocations would silently reuse.
     Returns the second element as a path only when *we* created the file and
     the caller must delete it afterward.
     """
@@ -34,8 +37,18 @@ def _resolve_genome_fna(genome_fna: str) -> tuple[str, str | None]:
     if os.path.exists(plain):
         return plain, None
     logger.info("Decompressing genome FASTA for gffread (random-access required): %s", genome_fna)
-    with gzip.open(genome_fna, "rb") as fi, open(plain, "wb") as fo:
-        shutil.copyfileobj(fi, fo)
+    tmp = plain + ".tmp"
+    try:
+        with gzip.open(genome_fna, "rb") as fi, open(tmp, "wb") as fo:
+            shutil.copyfileobj(fi, fo)
+        os.replace(tmp, plain)
+    except BaseException:
+        if os.path.exists(tmp):
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+        raise
     return plain, plain
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

Acts on the actionable findings from CodeRabbit (19 inline comments) and Copilot (2 inline comments) on #105. Each item was verified against the current state of `dev` before fixing; some prior reviews had already been resolved by #107 (`ensembl_downloader` silent assembly fallback) and #106 (broken NCBI/ClinVar anchor).

### Critical
- **`pgatk/cgenomes/cgenomes_proteindb.py` (`_cbio_translate_batch` DEL path)** — \`pos.split(\"del\")[1]\` returns \`\"\"\` for HGVS range-only deletions like \`c.104_124del\`, and the \`del_dna == seq[...]\` comparison then matched the empty slice — so the deletion was silently ignored and the reference sequence was emitted unchanged. Now: when \`del_dna\` is empty, derive the deletion length from the range in \`cdna_pos\` and apply the deletion by length, with a bounds check.

### Major
- **`pgatk/cgenomes/cbioportal_downloader.py`** — \`download_one_study\` writes to the shared \`url_file\` handle. Under \`--multithreading\` (up to 10 threads via \`ThreadPoolExecutor\`) those writes can interleave. The pool now passes \`url_file=None\` to workers and the main thread writes returned paths serially as futures complete. Serial code paths are unchanged. (Also flagged by Copilot.)
- **`pgatk/cgenomes/cosmic_downloader.py`** — on S3 download failure the error log included the full presigned URL including short-lived AWS query credentials. Strip the query string before formatting the error message (matches the success-path debug log).
- **`pgatk/clinvar/data_downloader.py`, `pgatk/ensembl/data_downloader.py`, `pgatk/gnomad/data_downloader.py`** — \`.gz → plain\` FASTA decompression wrote directly to the final path. An interrupted run left a partial sibling that later invocations silently reused, producing corrupt \`gffread\` output. Now staged through a \`.tmp\` file and atomically \`os.replace()\`d; the temp file is removed on any exception (including \`KeyboardInterrupt\`).
- **`pgatk/db/map_peptide2genome.parse_gtf`** — \`if line[0] != \"#\"\` raises \`IndexError\` on empty lines. Skip blank lines before the comment check; also guard the CDS path against short rows.
- **`docs/use-cases.md`** — Step 3 \`cat\` includes \`putative.fa\` but Step 2 never produced it, so the recipe didn't run end-to-end. Added the missing three-frame putative-protein generation step.

### Minor
- **`pgatk/commands/vcf_to_proteindb.py`** — \`--workers\` help said \`default: 1, sequential. Per-chromosome split.\`, but click default is \`None\` (config-driven, defaults to 1) and the actual strategy is fixed-size variant batches (~50k records) that may span chromosomes. Help text updated. (Also flagged by Copilot.)
- **`pgatk/ensembl/ensembl.py`** — \`_vcf_to_proteindb_worker\` annotated \`-> None\` but returns a stats dict that the caller aggregates. Annotation corrected to \`-> dict\`.
- **`docs/use-cases.md`** typos: \`annoated → annotated\`, \`Cancer-speific → Cancer-specific\` (x2), \`numbre → number\`.

### Skipped (with reason)
- **Worker validation (\`--workers >= 1\`) across cbioportal/clinvar/gnomad CLIs** — fixable in one pass with \`click.IntRange(min=1)\`; left for a separate \"CLI input validation\" PR since it touches multiple unrelated files and changes the parser surface.
- **\`ncbi_downloader\` overly broad except** — already narrowed to FileNotFoundError + CalledProcessError in #107.
- **Style nitpicks** — B202 comment placement, en-dash → hyphen in a log line, testing a private \`_cosmic_token\` attribute, moving stdlib imports out of a worker block, replacing \`[x for ...][0]\` with \`next(...)\`. Low-value style; not addressed.

## Test plan

- [x] \`python -m pytest pgatk/tests/ -q\` — 316 passed
- [x] \`python -m unittest discover -s pgatk/tests -p \"*_tests.py\"\` — 20 / 20
- [ ] Consider adding a targeted test for HGVS range-only deletions on the \`_cbio_translate_batch\` path (the existing COSMIC \`get_mut_pro_seq\` test covers the parallel function but not the cBioPortal path that was broken). Out of scope for this fix-only PR.